### PR TITLE
feature optionally allow all `.env` files to be stored in a folder, avoid cluttering root folder

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -14,11 +14,29 @@ class Application extends \Illuminate\Foundation\Application
     protected $environmentFile = null;
 
     /**
+     * The custom environment path defined by the developer.
+     *
+     * @var string
+     */
+    protected $environmentPath = null;
+
+    /**
      * @var bool
      *
      * False is the domain has never been detected
      */
     protected $domainDetected = false;
+
+    /**
+     * Create a new application instance.
+     * @param  string|null  $basePath
+     * @param  string|null  $environmentPath
+     */
+    public function __construct($basePath = null, $environmentPath = null)
+    {
+        $this->environmentPath = $environmentPath ?? $this->environmentPath;
+        parent::__construct($basePath);
+    }
 
     /**
      * Detect the application's current domain.
@@ -115,7 +133,7 @@ class Application extends \Illuminate\Foundation\Application
         if (is_null($domain)) {
             $domain = $this['domain'];
         }
-        $filePath = rtrim($this['path.base'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $filePath = rtrim($this->environmentPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         $file = '.env.' . $domain;
         return file_exists($filePath . $file) ? $file : '.env';
     }

--- a/src/Foundation/Console/AddDomainCommand.php
+++ b/src/Foundation/Console/AddDomainCommand.php
@@ -15,9 +15,9 @@ class AddDomainCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'domain:add 
-                            {domain : The name of the domain to add to the framework} 
-                            {--domain_values= : The optional values for the domain variables to be stored in the env file (json object)} 
+    protected $signature = 'domain:add
+                            {domain : The name of the domain to add to the framework}
+                            {--domain_values= : The optional values for the domain variables to be stored in the env file (json object)}
                             {--force : Force the creation of domain storage dirs also if they already exist}';
 
 
@@ -63,7 +63,7 @@ class AddDomainCommand extends GeneratorCommand
         if ($this->files->exists($this->getDomainEnvFilePath())) {
             return $this->getDomainEnvFilePath();
         }
-        return base_path() . DIRECTORY_SEPARATOR . Config::get('domain.env_stub', '.env');
+        return base_path(rtrim(app()->environmentPath(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . Config::get('domain.env_stub', '.env'));
     }
 
     protected function createDomainEnvFile()

--- a/src/Foundation/Console/DomainCommandTrait.php
+++ b/src/Foundation/Console/DomainCommandTrait.php
@@ -24,7 +24,8 @@ trait DomainCommandTrait
         if (is_null($domain)) {
             $domain = $this->domain;
         }
-        return base_path() . DIRECTORY_SEPARATOR . '.env.' . $domain;
+
+        return base_path(rtrim(app()->environmentPath(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '.env.' . $domain);
     }
 
     /**

--- a/src/Foundation/Console/UpdateEnvDomainCommand.php
+++ b/src/Foundation/Console/UpdateEnvDomainCommand.php
@@ -13,8 +13,8 @@ class UpdateEnvDomainCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'domain:update_env 
-                            {domain? : The name of the domain to which update the env (if empty all the env domains will be updated)} 
+    protected $signature = 'domain:update_env
+                            {domain? : The name of the domain to which update the env (if empty all the env domains will be updated)}
                             {--domain_values= : The optional values for the domain variables to be stored in the env file (json object)}';
 
 
@@ -52,7 +52,7 @@ class UpdateEnvDomainCommand extends GeneratorCommand
         }
 
         $envFiles = [
-            base_path() . DIRECTORY_SEPARATOR.'.env',
+            base_path(rtrim(app()->environmentPath(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '.env'),
         ];
         $domainList = Config::get('domain.domains',[]);
 


### PR DESCRIPTION
📁 
# Allow `.env` files to be stored in their own folder of a laravel installation

☕ Pull request fix for [issue 22 - Storing multiple `.env` files](https://github.com/gecche/laravel-multidomain/issues/22#issuecomment-610035931) - stop cluttering of the root folder with each new `.env.domain.com` file.

> Currently I will have around ~100 .env.site.com files sat in the root directory, I'm wondering how it could be possible to move into a subfolder like env/... or something...

⭐ Extended `Gecche\Multidomain\Foundation\Application(...)` to accept a second parameter `$environmentPath`

_✍ Couple of minor extra-spaces removed by my editor._