### PR TITLE
Made horizon pass --domain option on to workers properly

### DIFF
--- a/src/Horizon/Console/HorizonCommand.php
+++ b/src/Horizon/Console/HorizonCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon\Console;
+
+use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Laravel\Horizon\MasterSupervisor;
+use Gecche\Multidomain\Horizon\ProvisioningPlan;
+use Laravel\Horizon\Console\HorizonCommand as BaseHorizonCommand;
+
+/**
+ * Class HorizonCommand
+ *
+ * @package Gecche\Multidomain\Horizon\Console
+ */
+class HorizonCommand extends BaseHorizonCommand
+{
+    /**
+     * Execute the console command.
+     *
+     * @param  MasterSupervisorRepository  $masters
+     * @return void
+     */
+    public function handle(MasterSupervisorRepository $masters)
+    {
+        if ($masters->find(MasterSupervisor::name())) {
+            return $this->comment('A master supervisor is already running on this machine.');
+        }
+
+        $master = (new MasterSupervisor)->handleOutputUsing(function ($type, $line) {
+            $this->output->write($line);
+        });
+
+        ProvisioningPlan::get(MasterSupervisor::name(), $this->option('domain'))->deploy(
+            $this->option('environment') ?? config('horizon.env') ?? config('app.env')
+        );
+
+        $this->info('Horizon started successfully.');
+
+        pcntl_async_signals(true);
+
+        pcntl_signal(SIGINT, function () use ($master) {
+            $this->line('Shutting down...');
+
+            return $master->terminate();
+        });
+
+        $master->monitor();
+    }
+}

--- a/src/Horizon/Console/SupervisorCommand.php
+++ b/src/Horizon/Console/SupervisorCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon\Console;
+
+use Gecche\Multidomain\Horizon\SupervisorOptions;
+use Laravel\Horizon\Console\SupervisorCommand as BaseSupervisorCommand;
+
+/**
+ * Class SupervisorCommand
+ *
+ * @package Gecche\Multidomain\Horizon\Console
+ */
+class SupervisorCommand extends BaseSupervisorCommand
+{
+    /**
+     * Get the supervisor options.
+     *
+     * @return SupervisorOptions
+     */
+    protected function supervisorOptions()
+    {
+        $backoff = $this->hasOption('backoff')
+                    ? $this->option('backoff')
+                    : $this->option('delay');
+
+        return new SupervisorOptions(
+            $this->argument('name'),
+            $this->argument('connection'),
+            $this->getQueue($this->argument('connection')),
+            $this->option('workers-name'),
+            $this->option('balance'),
+            $backoff,
+            $this->option('max-time'),
+            $this->option('max-jobs'),
+            $this->option('max-processes'),
+            $this->option('min-processes'),
+            $this->option('memory'),
+            $this->option('timeout'),
+            $this->option('sleep'),
+            $this->option('tries'),
+            $this->option('force'),
+            $this->option('nice'),
+            $this->option('balance-cooldown'),
+            $this->option('balance-max-shift'),
+            $this->option('parent-id'),
+            $this->option('domain')
+        );
+    }
+}

--- a/src/Horizon/Console/TimeoutCommand.php
+++ b/src/Horizon/Console/TimeoutCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon\Console;
+
+use Laravel\Horizon\MasterSupervisor;
+use Gecche\Multidomain\Horizon\ProvisioningPlan;
+use Laravel\Horizon\Console\TimeoutCommand as BaseTimeoutCommand;
+
+/**
+ * Class TimeoutCommand
+ *
+ * @package Gecche\Multidomain\Horizon\Console
+ */
+class TimeoutCommand extends BaseTimeoutCommand
+{
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $plan = ProvisioningPlan::get(MasterSupervisor::name(), $this->option('domain'))->plan;
+
+        $this->line(collect($plan[$this->argument('environment')] ?? [])->max('timeout') ?? 60);
+    }
+}

--- a/src/Horizon/HorizonApplicationServiceProvider.php
+++ b/src/Horizon/HorizonApplicationServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon;
+
+use Gecche\Multidomain\Horizon\Console\HorizonCommand;
+use Gecche\Multidomain\Horizon\Console\SupervisorCommand;
+use Gecche\Multidomain\Horizon\Console\TimeoutCommand;
+use Laravel\Horizon\Console\HorizonCommand as BaseHorizonCommand;
+use Laravel\Horizon\Console\SupervisorCommand as BaseSupervisorCommand;
+use Laravel\Horizon\Console\TimeoutCommand as BaseTimeoutCommand;
+use Laravel\Horizon\HorizonApplicationServiceProvider as BaseHorizonApplicationServiceProvider;
+
+/**
+ * Class HorizonApplicationServiceProvider
+ *
+ * @package Gecche\Multidomain\Horizon
+ */
+class HorizonApplicationServiceProvider extends BaseHorizonApplicationServiceProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        parent::register();
+
+        $this->app->bind(BaseSupervisorCommand::class, SupervisorCommand::class);
+        $this->app->bind(BaseHorizonCommand::class, HorizonCommand::class);
+        $this->app->bind(BaseTimeoutCommand::class, TimeoutCommand::class);
+    }
+}

--- a/src/Horizon/MasterSupervisorCommands/AddSupervisor.php
+++ b/src/Horizon/MasterSupervisorCommands/AddSupervisor.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon\MasterSupervisorCommands;
+
+use Laravel\Horizon\MasterSupervisor;
+use Gecche\Multidomain\Horizon\SupervisorOptions;
+use Gecche\Multidomain\Horizon\SupervisorProcess;
+use Laravel\Horizon\MasterSupervisorCommands\AddSupervisor as BaseAddSupervisor;
+
+/**
+ * Class AddSupervisor
+ *
+ * @package Gecche\Multidomain\Horizon\MasterSupervisorCommands
+ */
+class AddSupervisor extends BaseAddSupervisor
+{
+    /**
+     * Process the command.
+     *
+     * @param  MasterSupervisor  $master
+     * @param  array  $options
+     * @return void
+     */
+    public function process(MasterSupervisor $master, array $options)
+    {
+        $options = SupervisorOptions::fromArray($options);
+
+        $master->supervisors[] = new SupervisorProcess(
+            $options, $this->createProcess($master, $options), function ($type, $line) use ($master) {
+            $master->output($type, $line);
+        });
+    }
+}

--- a/src/Horizon/ProvisioningPlan.php
+++ b/src/Horizon/ProvisioningPlan.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon;
+
+use Gecche\Multidomain\Horizon\MasterSupervisorCommands\AddSupervisor;
+use Laravel\Horizon\Contracts\HorizonCommandQueue;
+use Laravel\Horizon\MasterSupervisor;
+use Laravel\Horizon\ProvisioningPlan as BaseProvisioningPlan;
+use Laravel\Horizon\SupervisorOptions as BaseSupervisorOptions;
+
+/**
+ * Class ProvisioningPlan
+ *
+ * @package Gecche\Multidomain\Horizon
+ */
+class ProvisioningPlan extends BaseProvisioningPlan
+{
+    /**
+     * Get the current provisioning plan.
+     *
+     * @param  string  $master
+     * @param string $domain
+     * @return static
+     */
+    public static function get($master, string $domain = 'localhost')
+    {
+        $environments = config('horizon.environments');
+        $environments = ((is_array($environments)) ? array_map(static function ($group) use ($domain) {
+            return ((is_array($group)) ? array_map(static function ($supervisor) use ($domain) {
+                return ((is_array($supervisor)) ? ['domain' => $domain] + $supervisor : $supervisor);
+            }, $group) : $group);
+        }, $environments) : $environments);
+
+        return new static($master, $environments, config('horizon.defaults', []));
+    }
+
+    /**
+     * Add a supervisor with the given options.
+     *
+     * @param  BaseSupervisorOptions  $options
+     * @return void
+     */
+    protected function add(BaseSupervisorOptions $options)
+    {
+        app(HorizonCommandQueue::class)->push(
+            MasterSupervisor::commandQueueFor($this->master),
+            AddSupervisor::class,
+            $options->toArray()
+        );
+    }
+
+    /**
+     * Convert the given array of options into a SupervisorOptions instance.
+     *
+     * @param  string  $supervisor
+     * @param  array  $options
+     * @return SupervisorOptions
+     */
+    protected function convert($supervisor, $options)
+    {
+        return SupervisorOptions::fromArray(['domain' => $options['domain']] + parent::convert($supervisor, $options)->toArray());
+    }
+}

--- a/src/Horizon/QueueCommandString.php
+++ b/src/Horizon/QueueCommandString.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon;
+
+use Laravel\Horizon\QueueCommandString as BaseQueueCommandString;
+use Laravel\Horizon\SupervisorOptions as BaseSupervisorOptions;
+
+/**
+ * Class QueueCommandString
+ *
+ * @package Gecche\Multidomain\Horizon
+ */
+class QueueCommandString extends BaseQueueCommandString
+{
+    /**
+     * Get the additional option string for the command.
+     *
+     * @param  BaseSupervisorOptions  $options
+     * @param  bool  $paused
+     * @return string
+     */
+    public static function toOptionsString(BaseSupervisorOptions $options, $paused = false)
+    {
+        $string = sprintf('--backoff=%s --max-time=%s --max-jobs=%s --memory=%s --queue="%s" --sleep=%s --timeout=%s --tries=%s --domain="%s"',
+            $options->backoff, $options->maxTime, $options->maxJobs, $options->memory,
+            $options->queue, $options->sleep, $options->timeout, $options->maxTries,
+            (($options instanceof SupervisorOptions) ? $options->domain : 'localhost')
+        );
+
+        if ($options->force) {
+            $string .= ' --force';
+        }
+
+        if ($paused) {
+            $string .= ' --paused';
+        }
+
+        return $string;
+    }
+}

--- a/src/Horizon/SupervisorCommandString.php
+++ b/src/Horizon/SupervisorCommandString.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon;
+
+use Laravel\Horizon\SupervisorCommandString as BaseSupervisorCommandString;
+use Laravel\Horizon\SupervisorOptions;
+
+/**
+ * Class SupervisorCommandString
+ *
+ * @package Gecche\Multidomain\Horizon
+ */
+class SupervisorCommandString extends BaseSupervisorCommandString
+{
+    /**
+     * Get the additional option string for the command.
+     *
+     * @param  SupervisorOptions  $options
+     * @return string
+     */
+    public static function toOptionsString(SupervisorOptions $options)
+    {
+        return QueueCommandString::toSupervisorOptionsString($options);
+    }
+}

--- a/src/Horizon/SupervisorOptions.php
+++ b/src/Horizon/SupervisorOptions.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon;
+
+use Laravel\Horizon\SupervisorOptions as BaseSupervisorOptions;
+
+/**
+ * Class SupervisorOptions
+ *
+ * @property string $domain
+ *
+ * @package Gecche\Multidomain\Horizon
+ */
+class SupervisorOptions extends BaseSupervisorOptions
+{
+    public string $domain = 'localhost';
+
+    /**
+     * Create a new worker options instance.
+     *
+     * @param  string  $name
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  string  $workersName
+     * @param  string  $balance
+     * @param  int  $backoff
+     * @param  int  $maxTime
+     * @param  int  $maxJobs
+     * @param  int  $maxProcesses
+     * @param  int  $minProcesses
+     * @param  int  $memory
+     * @param  int  $timeout
+     * @param  int  $sleep
+     * @param  int  $maxTries
+     * @param  bool  $force
+     * @param  int  $nice
+     * @param  int  $balanceCooldown
+     * @param  int  $balanceMaxShift
+     * @param  int  $parentId
+     * @param string $domain
+     */
+    public function __construct($name,
+                                $connection,
+                                $queue = null,
+                                $workersName = 'default',
+                                $balance = 'off',
+                                $backoff = 0,
+                                $maxTime = 0,
+                                $maxJobs = 0,
+                                $maxProcesses = 1,
+                                $minProcesses = 1,
+                                $memory = 128,
+                                $timeout = 60,
+                                $sleep = 3,
+                                $maxTries = 0,
+                                $force = false,
+                                $nice = 0,
+                                $balanceCooldown = 3,
+                                $balanceMaxShift = 1,
+                                $parentId = 0,
+                                string $domain = 'localhost')
+    {
+        parent::__construct($name, $connection, $queue, $workersName, $balance, $backoff, $maxTime, $maxJobs, $maxProcesses, $minProcesses, $memory, $timeout, $sleep, $maxTries, $force, $nice, $balanceCooldown, $balanceMaxShift, $parentId);
+
+        $this->domain = $domain;
+    }
+
+    /**
+     * Get the command-line representation of the options for a supervisor.
+     *
+     * @return string
+     */
+    public function toSupervisorCommand()
+    {
+        return SupervisorCommandString::fromOptions($this);
+    }
+
+    /**
+     * Get the command-line representation of the options for a worker.
+     *
+     * @return string
+     */
+    public function toWorkerCommand()
+    {
+        return WorkerCommandString::fromOptions($this);
+    }
+
+    /**
+     * Convert the options to a raw array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'balance'         => $this->balance,
+            'connection'      => $this->connection,
+            'queue'           => $this->queue,
+            'backoff'         => $this->backoff,
+            'force'           => $this->force,
+            'maxProcesses'    => $this->maxProcesses,
+            'minProcesses'    => $this->minProcesses,
+            'maxTries'        => $this->maxTries,
+            'maxTime'         => $this->maxTime,
+            'maxJobs'         => $this->maxJobs,
+            'memory'          => $this->memory,
+            'nice'            => $this->nice,
+            'name'            => $this->name,
+            'workersName'     => $this->workersName,
+            'sleep'           => $this->sleep,
+            'timeout'         => $this->timeout,
+            'balanceCooldown' => $this->balanceCooldown,
+            'balanceMaxShift' => $this->balanceMaxShift,
+            'domain'          => $this->domain
+        ];
+    }
+}

--- a/src/Horizon/SupervisorProcess.php
+++ b/src/Horizon/SupervisorProcess.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon;
+
+use Gecche\Multidomain\Horizon\MasterSupervisorCommands\AddSupervisor;
+use Laravel\Horizon\Contracts\HorizonCommandQueue;
+use Laravel\Horizon\MasterSupervisor;
+use Laravel\Horizon\SupervisorProcess as BaseSupervisorProcess;
+
+/**
+ * Class SupervisorProcess
+ *
+ * @package Gecche\Multidomain\Horizon
+ */
+class SupervisorProcess extends BaseSupervisorProcess
+{
+    /**
+     * Re-provision this supervisor process based on the provisioning plan.
+     *
+     * @return void
+     */
+    protected function reprovision()
+    {
+        app(HorizonCommandQueue::class)->push(
+            MasterSupervisor::commandQueue(),
+            AddSupervisor::class,
+            $this->options->toArray()
+        );
+    }
+}

--- a/src/Horizon/WorkerCommandString.php
+++ b/src/Horizon/WorkerCommandString.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Gecche\Multidomain\Horizon;
+
+use Laravel\Horizon\WorkerCommandString as BaseWorkerCommandString;
+use Laravel\Horizon\SupervisorOptions;
+
+/**
+ * Class WorkerCommandString
+ *
+ * @package Gecche\Multidomain\Horizon
+ */
+class WorkerCommandString extends BaseWorkerCommandString
+{
+    /**
+     * Get the additional option string for the command.
+     *
+     * @param  SupervisorOptions  $options
+     * @return string
+     */
+    public static function toOptionsString(SupervisorOptions $options)
+    {
+        return QueueCommandString::toWorkerOptionsString($options);
+    }
+}


### PR DESCRIPTION
Running "php artisan horizon --domain=***" used to run properly except passing the domain option on to the worker command. This caused the application miss proper storage_path detection and such issues alike. Here's the fix.