### PR TITLE
Avoid passing null to strpos and explode

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -148,7 +148,7 @@ class Application extends \Illuminate\Foundation\Application
     {
         $this->checkDomainDetection();
 
-        $domain ??= $this['domain'] ?? '';
+        $domain = $domain ?? $this['domain'] ?? '';
 
         $envFile = $this->searchForEnvFileDomain(explode('.',$domain));
 

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -148,9 +148,7 @@ class Application extends \Illuminate\Foundation\Application
     {
         $this->checkDomainDetection();
 
-        if (is_null($domain)) {
-            $domain = $this['domain'];
-        }
+        $domain ??= $this['domain'] ?? '';
 
         $envFile = $this->searchForEnvFileDomain(explode('.',$domain));
 

--- a/src/Foundation/DomainDetector.php
+++ b/src/Foundation/DomainDetector.php
@@ -99,6 +99,8 @@ class DomainDetector {
      * Split the domain name into scheme, name and port
      */
     public function split($domain) {
+        $domain ??= '';
+
         if (Str::startsWith($domain,'https://')) {
             $scheme = 'https';
             $domain = substr($domain,8);

--- a/src/Foundation/DomainDetector.php
+++ b/src/Foundation/DomainDetector.php
@@ -99,7 +99,7 @@ class DomainDetector {
      * Split the domain name into scheme, name and port
      */
     public function split($domain) {
-        $domain ??= '';
+        $domain = $domain ?? '';
 
         if (Str::startsWith($domain,'https://')) {
             $scheme = 'https';


### PR DESCRIPTION
Passing null to non-nullable parameters of built-in functions is deprecated in PHP 8.1.