### PR TITLE
feat: add more list output for domain list

### DIFF
--- a/src/Foundation/Console/ListDomainCommand.php
+++ b/src/Foundation/Console/ListDomainCommand.php
@@ -13,8 +13,8 @@ class ListDomainCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'domain:list';
-
+    protected $signature = 'domain:list
+                            {--output=txt : the output type json or text (text as default)}';
 
     protected $description = "Lists domains installed in the application.";
 
@@ -28,7 +28,6 @@ class ListDomainCommand extends Command
         /*
          * GET CONFIG FILE
          */
-
         $filename = base_path('config/' . $this->configFile . '.php');
 
         $config = include $filename;
@@ -42,17 +41,44 @@ class ListDomainCommand extends Command
         /*
          * Simply returns the info for each domain found in config.
          */
-        foreach ($domains as $domain) {
-            $this->line("<info>Domain: </info><comment>" . $domain . "</comment>");
-
-            $this->line("<info> - Storage dir: </info><comment>" . $this->getDomainStoragePath($domain) . "</comment>");
-            $this->line("<info> - Env file: </info><comment>" . $this->getDomainEnvFilePath($domain) . "</comment>");
-
-            $this->line("");
-
-        }
-
-
+	    $outputType = $this->option('output');
+	    $domains = $this->buildResult($domains);
+	    switch (strtolower(trim($outputType ?? 'txt')))
+	    {
+		    default:
+		    case 'text':
+			    $this->outputAsText($domains);
+			    break;
+		    case 'table':
+			    $this->outputAsTable($domains);
+			    break;
+		    case 'json':
+			    $this->outputAsJson($domains);
+			    break;
+	    }
     }
 
+	protected function outputAsJson(array $domains)
+	{
+		$this->output->writeln(json_encode($domains));
+	}
+
+	protected function outputAsTable(array $domains)
+	{
+		$this->output->table(array_keys(head($domains)), $domains);
+	}
+
+	protected function buildResult(array $domains): array
+	{
+		$result = [];
+		foreach ($domains as $domain) {
+			$result []= [
+				'domain' => $domain,
+				'storage_dir' => $this->getDomainStoragePath($domain),
+				'env_file' => $this->getDomainEnvFilePath($domain),
+			];
+		}
+
+		return $result;
+	}
 }

--- a/src/Foundation/Console/ListDomainCommand.php
+++ b/src/Foundation/Console/ListDomainCommand.php
@@ -14,7 +14,7 @@ class ListDomainCommand extends Command
      * @var string
      */
     protected $signature = 'domain:list
-                            {--output=txt : the output type json or text (text as default)}';
+                            {--output=txt : the output type json or txt (txt as default)}';
 
     protected $description = "Lists domains installed in the application.";
 
@@ -46,7 +46,7 @@ class ListDomainCommand extends Command
 	    switch (strtolower(trim($outputType ?? 'txt')))
 	    {
 		    default:
-		    case 'text':
+		    case 'txt':
 			    $this->outputAsText($domains);
 			    break;
 		    case 'table':


### PR DESCRIPTION
The purpose of this was to ease the list of domain, including some json output that can easyly be parsed by scripts (help to deploy)

here is the output example with 1 site

![output-domain-list](https://user-images.githubusercontent.com/668804/157057227-0f7ff0b4-e3c7-4bef-9dfc-2bd7dd7dfa99.png)

