### PR TITLE
Fix PHP 8.4 deprecation by explicitly marking parameters as nullable

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -63,7 +63,7 @@ class Application extends \Illuminate\Foundation\Application
      * @param  array        $domainParams
      * @return \Gecche\Multidomain\Foundation\Configuration\ApplicationBuilder
      */
-    public static function configure(string $basePath = null, string $environmentPath = NULL, array $domainParams = [])
+    public static function configure(?string $basePath = null, ?string $environmentPath = null, array $domainParams = [])
     {
         $basePath = match (true) {
             is_string($basePath) => $basePath,


### PR DESCRIPTION
Updated the method signature of configure() in Gecche\Multidomain\Foundation\Application to explicitly mark the $basePath and $environmentPath parameters as nullable (?string). This resolves the deprecation warning introduced in PHP 8.4 regarding implicit nullability.

- Changed string $basePath = null to ?string $basePath = null
- Changed string $environmentPath = null to ?string $environmentPath = null