### PR TITLE
Removed empty elements from the tokens array.

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -178,6 +178,7 @@ class Application extends \Illuminate\Foundation\Application
     }
 
     protected function searchForEnvFileDomain($tokens = []) {
+        $tokens = array_filter($tokens);
         if (count($tokens) == 0) {
             return '.env';
         }


### PR DESCRIPTION
If for any reason the tokens array passed into the searchForEnvFileDomain method of the Application class, consists of an array of blank entries, then the method returns an environment file name of '.env.' , note the trailing '.' character.

To avoid this all blank entries are removed from the tokens array before it is checked for zero elements.